### PR TITLE
Lexing all the things

### DIFF
--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -11,11 +11,20 @@ const RANGE_OP:              &'static str = r"^\.\.";
 #[derive(Debug, PartialEq)]
 pub enum Token {
     Comparison(String),
-    EndOfString,
     Identifier(String),
     Number(String),
-    Range,
     String(String),
+    Range,
+    EndOfString,
+}
+
+macro_rules! token {
+    (Comparison => $e:expr) => (Token::Comparison(String::from($e)));
+    (Identifier => $e:expr) => (Token::Identifier(String::from($e)));
+    (Number => $e:expr) => (Token::Number(String::from($e)));
+    (String => $e:expr) => (Token::String(String::from($e)));
+    (Range) => (Token::Range);
+    (EndOfString) => (Token::EndOfString);
 }
 
 pub struct Tokens<'t> {
@@ -25,13 +34,13 @@ pub struct Tokens<'t> {
 impl<'t> Tokens<'t> {
     fn token_for(&self, pattern: &Regex, value: &str) -> Token {
         match pattern.as_str() {
-            COMPARISON => Token::Comparison(value.to_string()),
-            SINGLE_STRING_LITERAL => Token::String(value.to_string()),
-            DOUBLE_STRING_LITERAL => Token::String(value.to_string()),
-            NUMBER_LITERAL => Token::Number(value.to_string()),
-            IDENTIFIER => Token::Identifier(value.to_string()),
-            RANGE_OP => Token::Range,
-            _ => Token::EndOfString
+            COMPARISON            => token!(Comparison => value),
+            SINGLE_STRING_LITERAL => token!(String => value),
+            DOUBLE_STRING_LITERAL => token!(String => value),
+            NUMBER_LITERAL        => token!(Number => value),
+            IDENTIFIER            => token!(Identifier => value),
+            RANGE_OP              => token!(Range),
+            _                     => token!(EndOfString)
         }
     }
 }
@@ -105,8 +114,8 @@ mod tests {
         let tokens: Vec<Token> = lexer.tokens().collect();
 
         assert_eq!(2, tokens.len());
-        assert_eq!(Token::Identifier("high".to_string()), tokens[0]);
-        assert_eq!(Token::Identifier("five?".to_string()), tokens[1]);
+        assert_eq!(token!(Identifier => "high"), tokens[0]);
+        assert_eq!(token!(Identifier => "five?"), tokens[1]);
     }
 
     #[test]
@@ -115,10 +124,10 @@ mod tests {
         let tokens: Vec<Token> = lexer.tokens().collect();
 
         assert_eq!(4, tokens.len());
-        assert_eq!(Token::Number("2".to_string()), tokens[0]);
-        assert_eq!(Token::Identifier("foo".to_string()), tokens[1]);
-        assert_eq!(Token::Number("5.0".to_string()), tokens[2]);
-        assert_eq!(Token::Identifier("bar".to_string()), tokens[3]);
+        assert_eq!(token!(Number => "2"), tokens[0]);
+        assert_eq!(token!(Identifier => "foo"), tokens[1]);
+        assert_eq!(token!(Number => "5.0"), tokens[2]);
+        assert_eq!(token!(Identifier => "bar"), tokens[3]);
     }
 
     #[test]
@@ -127,8 +136,8 @@ mod tests {
         let tokens: Vec<Token> = lexer.tokens().collect();
 
         assert_eq!(2, tokens.len());
-        assert_eq!(Token::String(r#"'this is a test""'"#.to_string()), tokens[0]);
-        assert_eq!(Token::String(r#""wat 'lol'""#.to_string()), tokens[1]);
+        assert_eq!(token!(String => r#"'this is a test""'"#), tokens[0]);
+        assert_eq!(token!(String => r#""wat 'lol'""#), tokens[1]);
     }
 
     #[test]
@@ -137,8 +146,8 @@ mod tests {
         let tokens: Vec<Token> = lexer.tokens().collect();
 
         assert_eq!(2, tokens.len());
-        assert_eq!(Token::Identifier("hi".to_string()), tokens[0]);
-        assert_eq!(Token::Number("50".to_string()), tokens[1]);
+        assert_eq!(token!(Identifier => "hi"), tokens[0]);
+        assert_eq!(token!(Number => "50"), tokens[1]);
     }
 
     #[test]
@@ -147,8 +156,8 @@ mod tests {
         let tokens: Vec<Token> = lexer.tokens().collect();
 
         assert_eq!(2, tokens.len());
-        assert_eq!(Token::Identifier("hi".to_string()), tokens[0]);
-        assert_eq!(Token::Number("5.0".to_string()), tokens[1]);
+        assert_eq!(token!(Identifier => "hi"), tokens[0]);
+        assert_eq!(token!(Number => "5.0"), tokens[1]);
     }
 
     #[test]
@@ -157,9 +166,9 @@ mod tests {
         let tokens: Vec<Token> = lexer.tokens().collect();
 
         assert_eq!(3, tokens.len());
-        assert_eq!(Token::Comparison("==".to_string()), tokens[0]);
-        assert_eq!(Token::Comparison("<>".to_string()), tokens[1]);
-        assert_eq!(Token::Comparison("contains".to_string()), tokens[2]);
+        assert_eq!(token!(Comparison => "=="), tokens[0]);
+        assert_eq!(token!(Comparison => "<>"), tokens[1]);
+        assert_eq!(token!(Comparison => "contains"), tokens[2]);
     }
 
     #[test]
@@ -168,8 +177,8 @@ mod tests {
         let tokens: Vec<Token> = lexer.tokens().collect();
 
         assert_eq!(3, tokens.len());
-        assert_eq!(Token::Number("1".to_string()), tokens[0]);
-        assert_eq!(Token::Range, tokens[1]);
-        assert_eq!(Token::Number("10".to_string()), tokens[2]);
+        assert_eq!(token!(Number => "1"), tokens[0]);
+        assert_eq!(token!(Range), tokens[1]);
+        assert_eq!(token!(Number => "10"), tokens[2]);
     }
 }

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -30,21 +30,9 @@ pub enum Token {
 }
 
 macro_rules! token {
-    (Comparison   => $e:expr) => (Token::Comparison(String::from($e)));
-    (Identifier   => $e:expr) => (Token::Identifier(String::from($e)));
-    (Number       => $e:expr) => (Token::Number(String::from($e)));
-    (String       => $e:expr) => (Token::String(String::from($e)));
-    (Range)       => (Token::Range("..".into()));
-    (Pipe)        => (Token::Pipe);
-    (Dot)         => (Token::Dot);
-    (Colon)       => (Token::Colon);
-    (Comma)       => (Token::Comma);
-    (OpenSquare)  => (Token::OpenSquare);
-    (CloseSquare) => (Token::CloseSquare);
-    (OpenRound)   => (Token::OpenRound);
-    (CloseRound)  => (Token::CloseRound);
-    (Question)    => (Token::Question);
-    (Dash)        => (Token::Dash);
+    (Range)               => (token!(Range, ".."));
+    ($e:ident)            => (Token::$e);
+    ($e:ident, $str:expr) => (Token::$e(String::from($str)))
 }
 
 pub struct Tokens<'t> {
@@ -81,11 +69,11 @@ impl<'t> Tokens<'t> {
 
     fn token_for(&self, pattern: &Regex, value: &str) -> Token {
         match pattern.as_str() {
-            COMPARISON            => token!(Comparison => value),
-            SINGLE_STRING_LITERAL => token!(String => value),
-            DOUBLE_STRING_LITERAL => token!(String => value),
-            NUMBER_LITERAL        => token!(Number => value),
-            IDENTIFIER            => token!(Identifier => value),
+            COMPARISON            => token!(Comparison, value),
+            SINGLE_STRING_LITERAL => token!(String, value),
+            DOUBLE_STRING_LITERAL => token!(String, value),
+            NUMBER_LITERAL        => token!(Number, value),
+            IDENTIFIER            => token!(Identifier, value),
             RANGE_OP              => token!(Range),
             _                     => unreachable!() // already been checked for existence
         }
@@ -170,8 +158,8 @@ mod tests {
         let tokens: Vec<Token> = lexer.tokens().collect();
 
         assert_eq!(2, tokens.len());
-        assert_eq!(token!(Identifier => "high"), tokens[0]);
-        assert_eq!(token!(Identifier => "five?"), tokens[1]);
+        assert_eq!(token!(Identifier, "high"), tokens[0]);
+        assert_eq!(token!(Identifier, "five?"), tokens[1]);
     }
 
     #[test]
@@ -180,10 +168,10 @@ mod tests {
         let tokens: Vec<Token> = lexer.tokens().collect();
 
         assert_eq!(4, tokens.len());
-        assert_eq!(token!(Number => "2"), tokens[0]);
-        assert_eq!(token!(Identifier => "foo"), tokens[1]);
-        assert_eq!(token!(Number => "5.0"), tokens[2]);
-        assert_eq!(token!(Identifier => "bar"), tokens[3]);
+        assert_eq!(token!(Number, "2"), tokens[0]);
+        assert_eq!(token!(Identifier, "foo"), tokens[1]);
+        assert_eq!(token!(Number, "5.0"), tokens[2]);
+        assert_eq!(token!(Identifier, "bar"), tokens[3]);
     }
 
     #[test]
@@ -192,8 +180,8 @@ mod tests {
         let tokens: Vec<Token> = lexer.tokens().collect();
 
         assert_eq!(2, tokens.len());
-        assert_eq!(token!(String => r#"'this is a test""'"#), tokens[0]);
-        assert_eq!(token!(String => r#""wat 'lol'""#), tokens[1]);
+        assert_eq!(token!(String, r#"'this is a test""'"#), tokens[0]);
+        assert_eq!(token!(String, r#""wat 'lol'""#), tokens[1]);
     }
 
     #[test]
@@ -202,8 +190,8 @@ mod tests {
         let tokens: Vec<Token> = lexer.tokens().collect();
 
         assert_eq!(2, tokens.len());
-        assert_eq!(token!(Identifier => "hi"), tokens[0]);
-        assert_eq!(token!(Number => "50"), tokens[1]);
+        assert_eq!(token!(Identifier, "hi"), tokens[0]);
+        assert_eq!(token!(Number, "50"), tokens[1]);
     }
 
     #[test]
@@ -212,8 +200,8 @@ mod tests {
         let tokens: Vec<Token> = lexer.tokens().collect();
 
         assert_eq!(2, tokens.len());
-        assert_eq!(token!(Identifier => "hi"), tokens[0]);
-        assert_eq!(token!(Number => "5.0"), tokens[1]);
+        assert_eq!(token!(Identifier, "hi"), tokens[0]);
+        assert_eq!(token!(Number, "5.0"), tokens[1]);
     }
 
     #[test]
@@ -222,9 +210,9 @@ mod tests {
         let tokens: Vec<Token> = lexer.tokens().collect();
 
         assert_eq!(3, tokens.len());
-        assert_eq!(token!(Comparison => "=="), tokens[0]);
-        assert_eq!(token!(Comparison => "<>"), tokens[1]);
-        assert_eq!(token!(Comparison => "contains"), tokens[2]);
+        assert_eq!(token!(Comparison, "=="), tokens[0]);
+        assert_eq!(token!(Comparison, "<>"), tokens[1]);
+        assert_eq!(token!(Comparison, "contains"), tokens[2]);
     }
 
     #[test]
@@ -233,9 +221,9 @@ mod tests {
         let tokens: Vec<Token> = lexer.tokens().collect();
 
         assert_eq!(3, tokens.len());
-        assert_eq!(token!(Number => "1"), tokens[0]);
+        assert_eq!(token!(Number, "1"), tokens[0]);
         assert_eq!(token!(Range), tokens[1]);
-        assert_eq!(token!(Number => "10"), tokens[2]);
+        assert_eq!(token!(Number, "10"), tokens[2]);
     }
 
     #[test]
@@ -245,7 +233,7 @@ mod tests {
 
         assert_eq!(12, tokens.len());
         assert_eq!(token!(OpenSquare), tokens[0]);
-        assert_eq!(token!(Identifier => "hi"), tokens[1]);
+        assert_eq!(token!(Identifier, "hi"), tokens[1]);
         assert_eq!(token!(CloseSquare), tokens[2]);
         assert_eq!(token!(Comma), tokens[3]);
         assert_eq!(token!(OpenRound), tokens[4]);
@@ -255,7 +243,7 @@ mod tests {
         assert_eq!(token!(CloseRound), tokens[8]);
         assert_eq!(token!(Dash), tokens[9]);
         assert_eq!(token!(Question), tokens[10]);
-        assert_eq!(token!(Identifier => "cool"), tokens[11]);
+        assert_eq!(token!(Identifier, "cool"), tokens[11]);
     }
 
     #[test]
@@ -264,9 +252,9 @@ mod tests {
         let tokens: Vec<Token> = lexer.tokens().collect();
 
         assert_eq!(3, tokens.len());
-        assert_eq!(token!(Identifier => "five"), tokens[0]);
+        assert_eq!(token!(Identifier, "five"), tokens[0]);
         assert_eq!(token!(Pipe), tokens[1]);
-        assert_eq!(token!(Comparison => "=="), tokens[2]);
+        assert_eq!(token!(Comparison, "=="), tokens[2]);
     }
 
     #[test]

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -1,0 +1,175 @@
+use scanner::Scanner;
+use regex::Regex;
+
+const COMPARISON           : &'static str = r"^(==|!=|<>|<=?|>=?|contains)";
+const SINGLE_STRING_LITERAL: &'static str = r"^'[^']*'";
+const DOUBLE_STRING_LITERAL: &'static str = r#"^"[^"]*""#;
+const NUMBER_LITERAL:        &'static str = r"^-?\d+(\.\d+)?";
+const IDENTIFIER:            &'static str = r"^[a-zA-Z_][\w-]*\??";
+const RANGE_OP:              &'static str = r"^\.\.";
+
+#[derive(Debug, PartialEq)]
+pub enum Token {
+    Comparison(String),
+    EndOfString,
+    Identifier(String),
+    Number(String),
+    Range,
+    String(String),
+}
+
+pub struct Tokens<'t> {
+    scanner: &'t Scanner<'t>
+}
+
+impl<'t> Tokens<'t> {
+    fn token_for(&self, pattern: &Regex, value: &str) -> Token {
+        match pattern.as_str() {
+            COMPARISON => Token::Comparison(value.to_string()),
+            SINGLE_STRING_LITERAL => Token::String(value.to_string()),
+            DOUBLE_STRING_LITERAL => Token::String(value.to_string()),
+            NUMBER_LITERAL => Token::Number(value.to_string()),
+            IDENTIFIER => Token::Identifier(value.to_string()),
+            RANGE_OP => Token::Range,
+            _ => Token::EndOfString
+        }
+    }
+}
+
+impl<'t> Iterator for Tokens<'t> {
+    type Item = Token;
+
+    fn next(&mut self) -> Option<Token> {
+        let matchers = vec![
+            Regex::new(COMPARISON).unwrap(),
+            Regex::new(SINGLE_STRING_LITERAL).unwrap(),
+            Regex::new(DOUBLE_STRING_LITERAL).unwrap(),
+            Regex::new(NUMBER_LITERAL).unwrap(),
+            Regex::new(IDENTIFIER).unwrap(),
+            Regex::new(RANGE_OP).unwrap()
+        ];
+
+        match matchers.iter().find(|&m| self.scanner.check(m)) {
+            None => None,
+            Some(regex) => {
+                let value = self.scanner.scan(&regex).unwrap();
+                Some(self.token_for(&regex, &value))
+            }
+        }
+    }
+}
+
+pub struct Lexer<'t> {
+    scanner: Scanner<'t>
+}
+
+impl<'t> Lexer<'t> {
+    pub fn new<'a>(source: &'a str) -> Lexer<'a> {
+        Lexer { scanner: Scanner::new(source) }
+    }
+
+    pub fn tokens(&self) -> Tokens {
+        Tokens { scanner: &self.scanner }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_creates_a_new_instance() {
+        let lexer = Lexer::new("doSomthing | filter");
+        assert_eq!("doSomthing | filter", lexer.scanner.rest().unwrap());
+    }
+
+    #[test]
+    fn tokens_when_given_a_blank_string() {
+        let lexer              = Lexer::new("");
+        let tokens: Vec<Token> = lexer.tokens().collect();
+
+        assert_eq!(0, tokens.len());
+    }
+
+    #[test]
+    fn tokens_when_given_a_whitespace_only_string() {
+        let lexer              = Lexer::new("  \t \n\r ");
+        let tokens: Vec<Token> = lexer.tokens().collect();
+
+        assert_eq!(0, tokens.len());
+    }
+
+    #[test]
+    fn tokens_parses_identifiers() {
+        let lexer              = Lexer::new("high five?");
+        let tokens: Vec<Token> = lexer.tokens().collect();
+
+        assert_eq!(2, tokens.len());
+        assert_eq!(Token::Identifier("high".to_string()), tokens[0]);
+        assert_eq!(Token::Identifier("five?".to_string()), tokens[1]);
+    }
+
+    #[test]
+    fn tokens_knows_that_identifiers_dont_start_with_numbers() {
+        let lexer              = Lexer::new("2foo 5.0bar");
+        let tokens: Vec<Token> = lexer.tokens().collect();
+
+        assert_eq!(4, tokens.len());
+        assert_eq!(Token::Number("2".to_string()), tokens[0]);
+        assert_eq!(Token::Identifier("foo".to_string()), tokens[1]);
+        assert_eq!(Token::Number("5.0".to_string()), tokens[2]);
+        assert_eq!(Token::Identifier("bar".to_string()), tokens[3]);
+    }
+
+    #[test]
+    fn tokens_parses_string_literals() {
+        let lexer              = Lexer::new(r#" 'this is a test""' "wat 'lol'" "#);
+        let tokens: Vec<Token> = lexer.tokens().collect();
+
+        assert_eq!(2, tokens.len());
+        assert_eq!(Token::String(r#"'this is a test""'"#.to_string()), tokens[0]);
+        assert_eq!(Token::String(r#""wat 'lol'""#.to_string()), tokens[1]);
+    }
+
+    #[test]
+    fn tokens_parses_integers() {
+        let lexer              = Lexer::new("hi 50");
+        let tokens: Vec<Token> = lexer.tokens().collect();
+
+        assert_eq!(2, tokens.len());
+        assert_eq!(Token::Identifier("hi".to_string()), tokens[0]);
+        assert_eq!(Token::Number("50".to_string()), tokens[1]);
+    }
+
+    #[test]
+    fn tokens_parses_floats() {
+        let lexer              = Lexer::new("hi 5.0");
+        let tokens: Vec<Token> = lexer.tokens().collect();
+
+        assert_eq!(2, tokens.len());
+        assert_eq!(Token::Identifier("hi".to_string()), tokens[0]);
+        assert_eq!(Token::Number("5.0".to_string()), tokens[1]);
+    }
+
+    #[test]
+    fn tokens_parses_comparisons() {
+        let lexer              = Lexer::new("== <> contains");
+        let tokens: Vec<Token> = lexer.tokens().collect();
+
+        assert_eq!(3, tokens.len());
+        assert_eq!(Token::Comparison("==".to_string()), tokens[0]);
+        assert_eq!(Token::Comparison("<>".to_string()), tokens[1]);
+        assert_eq!(Token::Comparison("contains".to_string()), tokens[2]);
+    }
+
+    #[test]
+    fn tokens_parses_range_operator() {
+        let lexer              = Lexer::new("1..10");
+        let tokens: Vec<Token> = lexer.tokens().collect();
+
+        assert_eq!(3, tokens.len());
+        assert_eq!(Token::Number("1".to_string()), tokens[0]);
+        assert_eq!(Token::Range, tokens[1]);
+        assert_eq!(Token::Number("10".to_string()), tokens[2]);
+    }
+}

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -14,8 +14,7 @@ pub enum Token {
     Identifier(String),
     Number(String),
     String(String),
-    Range,
-    EndOfString,
+    Range(String)
 }
 
 macro_rules! token {
@@ -23,8 +22,7 @@ macro_rules! token {
     (Identifier => $e:expr) => (Token::Identifier(String::from($e)));
     (Number => $e:expr) => (Token::Number(String::from($e)));
     (String => $e:expr) => (Token::String(String::from($e)));
-    (Range) => (Token::Range);
-    (EndOfString) => (Token::EndOfString);
+    (Range) => (Token::Range("..".into()));
 }
 
 pub struct Tokens<'t> {
@@ -40,7 +38,7 @@ impl<'t> Tokens<'t> {
             NUMBER_LITERAL        => token!(Number => value),
             IDENTIFIER            => token!(Identifier => value),
             RANGE_OP              => token!(Range),
-            _                     => token!(EndOfString)
+            _                     => unreachable!()
         }
     }
 }

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -130,6 +130,15 @@ impl<'t> Lexer<'t> {
 mod tests {
     use super::*;
 
+    fn compare_tokens(lexer: &Lexer, expectedTokens: Vec<Token>) {
+        let zipped = lexer.tokens().zip(expectedTokens);
+
+        for token in zipped {
+            let (actual, expected) = token;
+            assert_eq!(expected, actual);
+        }
+    }
+
     #[test]
     fn new_creates_a_new_instance() {
         let lexer = Lexer::new("doSomthing | filter");
@@ -154,107 +163,116 @@ mod tests {
 
     #[test]
     fn tokens_parses_identifiers() {
-        let lexer              = Lexer::new("high five?");
-        let tokens: Vec<Token> = lexer.tokens().collect();
+        let lexer    = Lexer::new("high five?");
+        let expected = vec![
+            token!(Identifier, "high"),
+            token!(Identifier, "five?")
+        ];
 
-        assert_eq!(2, tokens.len());
-        assert_eq!(token!(Identifier, "high"), tokens[0]);
-        assert_eq!(token!(Identifier, "five?"), tokens[1]);
+        compare_tokens(&lexer, expected);
     }
 
     #[test]
     fn tokens_knows_that_identifiers_dont_start_with_numbers() {
-        let lexer              = Lexer::new("2foo 5.0bar");
-        let tokens: Vec<Token> = lexer.tokens().collect();
+        let lexer    = Lexer::new("2foo 5.0bar");
+        let expected = vec![
+            token!(Number, "2"),
+            token!(Identifier, "foo"),
+            token!(Number, "5.0"),
+            token!(Identifier, "bar")
+        ];
 
-        assert_eq!(4, tokens.len());
-        assert_eq!(token!(Number, "2"), tokens[0]);
-        assert_eq!(token!(Identifier, "foo"), tokens[1]);
-        assert_eq!(token!(Number, "5.0"), tokens[2]);
-        assert_eq!(token!(Identifier, "bar"), tokens[3]);
+        compare_tokens(&lexer, expected);
     }
 
     #[test]
     fn tokens_parses_string_literals() {
-        let lexer              = Lexer::new(r#" 'this is a test""' "wat 'lol'" "#);
-        let tokens: Vec<Token> = lexer.tokens().collect();
+        let lexer    = Lexer::new(r#" 'this is a test""' "wat 'lol'" "#);
+        let expected = vec![
+            token!(String, r#"'this is a test""'"#),
+            token!(String, r#""wat 'lol'""#)
+        ];
 
-        assert_eq!(2, tokens.len());
-        assert_eq!(token!(String, r#"'this is a test""'"#), tokens[0]);
-        assert_eq!(token!(String, r#""wat 'lol'""#), tokens[1]);
+        compare_tokens(&lexer, expected);
     }
 
     #[test]
     fn tokens_parses_integers() {
-        let lexer              = Lexer::new("hi 50");
-        let tokens: Vec<Token> = lexer.tokens().collect();
+        let lexer    = Lexer::new("hi 50");
+        let expected = vec![
+            token!(Identifier, "hi"),
+            token!(Number, "50")
+        ];
 
-        assert_eq!(2, tokens.len());
-        assert_eq!(token!(Identifier, "hi"), tokens[0]);
-        assert_eq!(token!(Number, "50"), tokens[1]);
+        compare_tokens(&lexer, expected);
     }
 
     #[test]
     fn tokens_parses_floats() {
-        let lexer              = Lexer::new("hi 5.0");
-        let tokens: Vec<Token> = lexer.tokens().collect();
+        let lexer    = Lexer::new("hi 5.0");
+        let expected = vec![
+            token!(Identifier, "hi"),
+            token!(Number, "5.0")
+        ];
 
-        assert_eq!(2, tokens.len());
-        assert_eq!(token!(Identifier, "hi"), tokens[0]);
-        assert_eq!(token!(Number, "5.0"), tokens[1]);
+        compare_tokens(&lexer, expected);
     }
 
     #[test]
     fn tokens_parses_comparisons() {
-        let lexer              = Lexer::new("== <> contains");
-        let tokens: Vec<Token> = lexer.tokens().collect();
+        let lexer    = Lexer::new("== <> contains");
+        let expected = vec![
+            token!(Comparison, "=="),
+            token!(Comparison, "<>"),
+            token!(Comparison, "contains")
+        ];
 
-        assert_eq!(3, tokens.len());
-        assert_eq!(token!(Comparison, "=="), tokens[0]);
-        assert_eq!(token!(Comparison, "<>"), tokens[1]);
-        assert_eq!(token!(Comparison, "contains"), tokens[2]);
+        compare_tokens(&lexer, expected);
     }
 
     #[test]
     fn tokens_parses_range_operator() {
-        let lexer              = Lexer::new("1..10");
-        let tokens: Vec<Token> = lexer.tokens().collect();
+        let lexer    = Lexer::new("1..10");
+        let expected = vec![
+            token!(Number, "1"),
+            token!(Range),
+            token!(Number, "10")
+        ];
 
-        assert_eq!(3, tokens.len());
-        assert_eq!(token!(Number, "1"), tokens[0]);
-        assert_eq!(token!(Range), tokens[1]);
-        assert_eq!(token!(Number, "10"), tokens[2]);
+        compare_tokens(&lexer, expected);
     }
 
     #[test]
     fn tokens_parses_special_characters() {
-        let lexer              = Lexer::new("[hi], (| .:) - ?cool");
-        let tokens: Vec<Token> = lexer.tokens().collect();
+        let lexer    = Lexer::new("[hi], (| .:) - ?cool");
+        let expected = vec![
+            token!(OpenSquare),
+            token!(Identifier, "hi"),
+            token!(CloseSquare),
+            token!(Comma),
+            token!(OpenRound),
+            token!(Pipe),
+            token!(Dot),
+            token!(Colon),
+            token!(CloseRound),
+            token!(Dash),
+            token!(Question),
+            token!(Identifier, "cool")
+        ];
 
-        assert_eq!(12, tokens.len());
-        assert_eq!(token!(OpenSquare), tokens[0]);
-        assert_eq!(token!(Identifier, "hi"), tokens[1]);
-        assert_eq!(token!(CloseSquare), tokens[2]);
-        assert_eq!(token!(Comma), tokens[3]);
-        assert_eq!(token!(OpenRound), tokens[4]);
-        assert_eq!(token!(Pipe), tokens[5]);
-        assert_eq!(token!(Dot), tokens[6]);
-        assert_eq!(token!(Colon), tokens[7]);
-        assert_eq!(token!(CloseRound), tokens[8]);
-        assert_eq!(token!(Dash), tokens[9]);
-        assert_eq!(token!(Question), tokens[10]);
-        assert_eq!(token!(Identifier, "cool"), tokens[11]);
+        compare_tokens(&lexer, expected);
     }
 
     #[test]
     fn tokens_skips_internal_whitespace() {
-        let lexer              = Lexer::new("five|\n\t  ==");
-        let tokens: Vec<Token> = lexer.tokens().collect();
+        let lexer    = Lexer::new("five|\n\t ==");
+        let expected = vec![
+            token!(Identifier, "five"),
+            token!(Pipe),
+            token!(Comparison, "==")
+        ];
 
-        assert_eq!(3, tokens.len());
-        assert_eq!(token!(Identifier, "five"), tokens[0]);
-        assert_eq!(token!(Pipe), tokens[1]);
-        assert_eq!(token!(Comparison, "=="), tokens[2]);
+        compare_tokens(&lexer, expected);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
 extern crate regex;
 
 mod scanner;
+mod lexer;


### PR DESCRIPTION
@tahnok, you mentioned you might be interested in working on this, so I thought I'd ping you here.
# WAT

Adding a lexer to handle tokenization of liquid strings. The basic idea is that I walk through the supplied string (via a `Scanner`) taking one token at a time until either the end of the string is reach or I encounter a syntax error.

This is just a lexer and therefore no attempt is made to make sense of the supplied strings (i.e. no grammar checks). Just that it consists of valid tokens.

For examples, the tests are the best place to look.
