### PR TITLE
Tokenization is now a thing!

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,3 +2,4 @@ extern crate regex;
 
 mod scanner;
 mod lexer;
+mod tokenizer;

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -55,11 +55,14 @@ impl<'t> Tokenizer<'t> {
         if slices.is_empty() { return vec![(0, self.source.len())]; }
 
         let mut missing = self.missing_middle_slices(slices);
-        let first       = self.missing_first_slice(slices);
-        let last        = self.missing_last_slice(slices);
 
-        if first.is_some() { missing.push(first.unwrap()) }
-        if last.is_some()  { missing.push(last.unwrap()) }
+        if let Some(first) = self.missing_first_slice(slices) {
+            missing.push(first);
+        }
+
+        if let Some(last) = self.missing_last_slice(slices) {
+            missing.push(last);
+        }
 
         missing
     }

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -173,4 +173,50 @@ mod tests {
             " "
         ]);
     }
+
+    #[test]
+    fn tokenize_multiline_string() {
+        let tokenizer = Tokenizer::new("{%comment%}\nMy Comment\n{%endcomment%}\n");
+
+        assert_tokens(&tokenizer, vec![
+            "{%comment%}",
+            "\nMy Comment\n",
+            "{%endcomment%}",
+            "\n"
+        ]);
+    }
+
+    #[test]
+    fn tokenize_html_with_liquid() {
+        let content = r#"
+<html>
+  <head>
+    <title>{{ title }}</title>
+  </head>
+  <body class="some-class">
+    <p>{% comment %}Content here{% endcomment %}</p>
+    <script type="text/javascript">
+      var {{ name }} = function() {
+        alert("{{ js_value }}");
+      };
+    </script>
+  </body>
+</html>
+        "#;
+
+        let tokenizer = Tokenizer::new(&content);
+        assert_tokens(&tokenizer, vec![
+            "\n<html>\n  <head>\n    <title>",
+            "{{ title }}",
+            "</title>\n  </head>\n  <body class=\"some-class\">\n    <p>",
+            "{% comment %}",
+            "Content here",
+            "{% endcomment %}",
+            "</p>\n    <script type=\"text/javascript\">\n      var ",
+            "{{ name }}",
+            " = function() {\n        alert(\"",
+            "{{ js_value }}",
+            "\");\n      };\n    </script>\n  </body>\n</html>\n        "
+        ]);
+    }
 }

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -108,6 +108,18 @@ mod tests {
     }
 
     #[test]
+    fn tokenize_blank_string() {
+        let tokenizer = Tokenizer::new("");
+        assert_tokens(&tokenizer, vec![""]);
+    }
+
+    #[test]
+    fn tokenize_whitespace_only_string() {
+        let tokenizer = Tokenizer::new("  ");
+        assert_tokens(&tokenizer, vec!["  "]);
+    }
+
+    #[test]
     fn tokenize_string_with_no_matches() {
         let tokenizer = Tokenizer::new("hello world");
         assert_tokens(&tokenizer, vec!["hello world"]);
@@ -139,5 +151,26 @@ mod tests {
         ];
 
         assert_tokens(&tokenizer, expected);
+    }
+
+    #[test]
+    fn tokenize_single_block() {
+        let tokenizer = Tokenizer::new(" {%comment%} ");
+        assert_tokens(&tokenizer, vec![" ", "{%comment%}", " "]);
+    }
+
+    #[test]
+    fn tokenize_empty_block_tag() {
+        let tokenizer = Tokenizer::new(" {% thing %} {% comment %} My comment here {% endcomment %} ");
+
+        assert_tokens(&tokenizer, vec![
+            " ",
+            "{% thing %}",
+            " ",
+            "{% comment %}",
+            " My comment here ",
+            "{% endcomment %}",
+            " "
+        ]);
     }
 }


### PR DESCRIPTION
@tahnok 

After waaaay too much time, I was able to get a tokenizer set up. It works similarly to Ruby's `String#split` in that it will split the string using the provided `Regex`, but also include the results in the split.

So for example, `{% comment %} My comment {% endcomment %} Some Text` will break down to:
- `" "`
- `"{% comment %}"`
- `"  My comment "`
- `"{% endcomment %}`
- `" Some Text"`

There's nothing here that enforces any kind of grammar. We can tackle that when we get to the parser.

**The Shitty Bit**

For now, it collects the mapped string slices since dealing with `Map<Iter<'t, (usize, usize)>, FnMut(blah blah blah` was fighteningly difficult. Eventually we can work on pushing the collect call further up the call stack.
